### PR TITLE
Redux Persist

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "redux": "^4.1.0",
+    "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
     "styled-components": "^5.3.0",
     "sweetalert": "^2.1.2",

--- a/client/src/Components/AddCategoryForm.js
+++ b/client/src/Components/AddCategoryForm.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react"
-import Nav from "./Nav/Nav"
 import swal from 'sweetalert';
 const axios = require('axios');
 

--- a/client/src/Components/Catalogue/Catalogue.jsx
+++ b/client/src/Components/Catalogue/Catalogue.jsx
@@ -1,27 +1,27 @@
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import "./catalogo.css"
 import ProductCard from "../ProductCard/ProductCard"
 import FilterCatalogue from './FilterCatalogue/FilterCatalogue';
 import { useLocation } from 'react-router-dom';
-import { getCategories, getProducts, getProdutsByCategory } from '../../actions/actions';
 
 export default function Catalogue() {
+
+  const query = useLocation().search;
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  const products = useSelector((state) => state.products);
+  const products = useSelector((state) => query.includes('search') ? state.productsByQuery : state.products);
 
   const [productsDisplay, setProductsDisplay] = useState([...products]);
-
 
   return (
     <div className="catalogue">
       <FilterCatalogue products={productsDisplay} setProducts={setProductsDisplay} />
       <div className='catalogueMap'>
-        {!productsDisplay.length ? <h1>Lo siento, no se encontraron coincidencias</h1> : null}
+        {!productsDisplay.length ? <h1>Lo lamentamos, no se encontraron coincidencias</h1> : null}
         {productsDisplay.map(product => {
           return <ProductCard product={product} name={product.name} price={product.price} id={product.id} image={product.image} review={product.review}></ProductCard>
         })}
@@ -31,16 +31,3 @@ export default function Catalogue() {
   );
 };
 
-
-/*
-  const query = useLocation().search.replaceAll('%20', ' ').substr(1);
-  const dispatch = useDispatch();
-  const categories = useSelector(state => state.categories);
-  if (!categories.length) dispatch(getCategories());
-
-  if (query === 'search');// cargo lo buscado
-  else {
-    const category = categories.find(category => category.name === query);
-    category ? dispatch(getProdutsByCategory(category.id)) : dispatch(getProducts())
-  }
-*/

--- a/client/src/Components/Catalogue/Catalogue.jsx
+++ b/client/src/Components/Catalogue/Catalogue.jsx
@@ -8,23 +8,11 @@ import { getCategories, getProducts, getProdutsByCategory } from '../../actions/
 
 export default function Catalogue() {
 
-  const query = useLocation().search.replaceAll('%20', ' ').substr(1);
-  const dispatch = useDispatch();
-  const categories = useSelector(state => state.categories);
-  if (!categories.length) dispatch(getCategories());
-
-  if (query === 'search');// cargo lo buscado
-  else {
-    const category = categories.find(category => category.name === query);
-    category ? dispatch(getProdutsByCategory(category.id)) : dispatch(getProducts())
-  }
-
   const products = useSelector((state) => state.products);
 
   const [productsDisplay, setProductsDisplay] = useState([...products]);
 
-  React.useEffect(()=>{},[query])
-  
+
   return (
     <div className="catalogue">
       <FilterCatalogue products={productsDisplay} setProducts={setProductsDisplay} />
@@ -40,3 +28,15 @@ export default function Catalogue() {
 };
 
 
+/* 
+  const query = useLocation().search.replaceAll('%20', ' ').substr(1);
+  const dispatch = useDispatch();
+  const categories = useSelector(state => state.categories);
+  if (!categories.length) dispatch(getCategories());
+
+  if (query === 'search');// cargo lo buscado
+  else {
+    const category = categories.find(category => category.name === query);
+    category ? dispatch(getProdutsByCategory(category.id)) : dispatch(getProducts())
+  }
+*/

--- a/client/src/Components/Catalogue/Catalogue.jsx
+++ b/client/src/Components/Catalogue/Catalogue.jsx
@@ -7,19 +7,19 @@ import { useLocation } from 'react-router-dom';
 
 export default function Catalogue() {
 
-  const query = useLocation().search;
+  const isQuery = useLocation().search.includes('search')
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  const products = useSelector((state) => query.includes('search') ? state.productsByQuery : state.products);
+  const products = useSelector((state) => isQuery ? state.productsByQuery : state.products);
 
   const [productsDisplay, setProductsDisplay] = useState([...products]);
 
   return (
     <div className="catalogue">
-      <FilterCatalogue products={productsDisplay} setProducts={setProductsDisplay} />
+      <FilterCatalogue products={productsDisplay} setProducts={setProductsDisplay} isQuery={isQuery} />
       <div className='catalogueMap'>
         {!productsDisplay.length ? <h1>Lo lamentamos, no se encontraron coincidencias</h1> : null}
         {productsDisplay.map(product => {

--- a/client/src/Components/Catalogue/Catalogue.jsx
+++ b/client/src/Components/Catalogue/Catalogue.jsx
@@ -19,7 +19,7 @@ export default function Catalogue() {
 
   return (
     <div className="catalogue">
-      <FilterCatalogue products={productsDisplay} setProducts={setProductsDisplay} isQuery={isQuery} />
+      <FilterCatalogue products={productsDisplay} setProducts={setProductsDisplay} productsGlobal={products} />
       <div className='catalogueMap'>
         {!productsDisplay.length ? <h1>Lo lamentamos, no se encontraron coincidencias</h1> : null}
         {productsDisplay.map(product => {

--- a/client/src/Components/Catalogue/Catalogue.jsx
+++ b/client/src/Components/Catalogue/Catalogue.jsx
@@ -12,7 +12,7 @@ export default function Catalogue() {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
-
+  
   const products = useSelector((state) => isQuery ? state.productsByQuery : state.products);
 
   const [productsDisplay, setProductsDisplay] = useState([...products]);

--- a/client/src/Components/Catalogue/Catalogue.jsx
+++ b/client/src/Components/Catalogue/Catalogue.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import "./catalogo.css"
 import ProductCard from "../ProductCard/ProductCard"
@@ -7,6 +7,10 @@ import { useLocation } from 'react-router-dom';
 import { getCategories, getProducts, getProdutsByCategory } from '../../actions/actions';
 
 export default function Catalogue() {
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const products = useSelector((state) => state.products);
 
@@ -28,7 +32,7 @@ export default function Catalogue() {
 };
 
 
-/* 
+/*
   const query = useLocation().search.replaceAll('%20', ' ').substr(1);
   const dispatch = useDispatch();
   const categories = useSelector(state => state.categories);

--- a/client/src/Components/Catalogue/FilterCatalogue/FilterCatalogue.js
+++ b/client/src/Components/Catalogue/FilterCatalogue/FilterCatalogue.js
@@ -7,9 +7,8 @@ import { sortAscending, sortDescending, sortNameAsc, sortNameDesc } from './util
 import { findByPrice, findByStars } from './utils/finds';
 
 
-export default function FilterCatalogue({ products, setProducts, isQuery }) {
+export default function FilterCatalogue({ products, setProducts, productsGlobal }) {
 
-    const productsGlobal = useSelector((state) => isQuery ? state.productsByQuery : state.products)
     const [input, setInput] = useState({ min: '', max: '' });
     const [undo, setUndo] = useState(false);
 
@@ -20,6 +19,8 @@ export default function FilterCatalogue({ products, setProducts, isQuery }) {
     useEffect(() => {
         document.getElementById('submit').disabled = (!input.min || !input.max || !Number(input.min) || !Number(input.max))
     }, [input]);
+
+
 
     const handleChoise = (e) => {
 
@@ -36,16 +37,16 @@ export default function FilterCatalogue({ products, setProducts, isQuery }) {
     return (
         <div className='ctnFiltersCat  bg-color-six'>
             <h1>{products.length} Resultados</h1>
-            {undo && <StyledButton text={'Deshacer'} handleClick={() => setProducts([...productsGlobal])} ></StyledButton>}
+            {undo && <StyledButton text={'Deshacer'} handleClick={() => { setProducts([...productsGlobal]); setUndo(false)}} ></StyledButton>}
             <h3>Ver </h3>
             <h5>Alfabéticamente</h5>
-            <p onClick={() => setProducts([...sortNameAsc(products)])}>A-Z</p>
-            <p onClick={() => setProducts([...sortNameDesc(products)])}>Z-A</p>
+            <p onClick={() => { setProducts([...sortNameAsc(products)]); setUndo(true) }}>A-Z</p>
+            <p onClick={() => { setProducts([...sortNameDesc(products)]); setUndo(true) }}>Z-A</p>
 
 
             <h5>Precio</h5>
-            <p onClick={() => setProducts([...sortDescending(products, 'price')])}>Mayor</p>
-            <p onClick={() => setProducts([...sortAscending(products, 'price')])}>Menor</p>
+            <p onClick={() => { setProducts([...sortDescending(products, 'price')]); setUndo(true) }}>Mayor</p>
+            <p onClick={() => { setProducts([...sortAscending(products, 'price')]); setUndo(true) }}>Menor</p>
 
             <form onSubmit={handleChoise}>
                 <input name='min' placeholder='Minimo..' onChange={handleInputChange} />
@@ -55,10 +56,10 @@ export default function FilterCatalogue({ products, setProducts, isQuery }) {
             </form>
 
             <h5>Estrellas</h5>
-            <div onClick={() => setProducts([...sortDescending(products, 'review')])} >Mas Estrellas
+            <div onClick={() => { setProducts([...sortDescending(products, 'review')]); setUndo(true) }} >Mas Estrellas
                 <ReactStars count={5} size={20} edit={false} value={5} activeColor="#ffd700" /></div>
 
-            <div onClick={() => setProducts([...sortAscending(products, 'review')])}>Menos Estrellas
+            <div onClick={() => { setProducts([...sortAscending(products, 'review')]); setUndo(true) }}>Menos Estrellas
                 <ReactStars count={5} size={20} edit={false} value={2} activeColor="#ffd700" /></div>
 
             <span>Elegir</span>

--- a/client/src/Components/Catalogue/FilterCatalogue/FilterCatalogue.js
+++ b/client/src/Components/Catalogue/FilterCatalogue/FilterCatalogue.js
@@ -7,9 +7,9 @@ import { sortAscending, sortDescending, sortNameAsc, sortNameDesc } from './util
 import { findByPrice, findByStars } from './utils/finds';
 
 
-export default function FilterCatalogue({ products, setProducts }) {
+export default function FilterCatalogue({ products, setProducts, isQuery }) {
 
-    const productsGlobal = useSelector((state) => state.products);
+    const productsGlobal = useSelector((state) => isQuery ? state.productsByQuery : state.products)
     const [input, setInput] = useState({ min: '', max: '' });
     const [undo, setUndo] = useState(false);
 

--- a/client/src/Components/Filters/CardFilter/CardFilter.js
+++ b/client/src/Components/Filters/CardFilter/CardFilter.js
@@ -2,18 +2,22 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import './CardFilter.css'
 import StyledButton from '../../../StyledComponents/Button';
+import { useDispatch } from 'react-redux';
+import { getProdutsByCategory } from '../../../actions/actions';
 
 
 export default function CardFilter({ id, name, img }) {
 
+    const dispatch = useDispatch();
+
     return (
-        <div className='ctnCardC'>
-            <a href={'/products?' + name}>
+        <div className='ctnCardC' onClick={() => dispatch(getProdutsByCategory(id))}>
+            <Link to={'/products?' + name}>
                 <div className='headerCard'>
                     <img src={img} alt={name} />
                 </div>
                 <StyledButton text={name} />
-            </a>
+            </Link>
         </div>
     )
 }

--- a/client/src/Components/Filters/Filters.css
+++ b/client/src/Components/Filters/Filters.css
@@ -20,3 +20,6 @@
     width: 100%;
     justify-content: center;
 }
+.ctnFilters .ctnCards button:hover{
+    transform: scale(1);
+}

--- a/client/src/Components/Filters/Filters.js
+++ b/client/src/Components/Filters/Filters.js
@@ -2,12 +2,14 @@ import React from 'react';
 import './Filters.css';
 import CardFilter from './CardFilter/CardFilter';
 import StyledButton from '../../StyledComponents/Button';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { getProducts } from '../../actions/actions';
 
 export default function Filters() {
 
     const categories = useSelector(state => state.categories)
+    const dispatch = useDispatch();
 
     return (
         <div className='ctnFilters'>
@@ -17,7 +19,7 @@ export default function Filters() {
                     <CardFilter id={cat.id} name={cat.name} img={cat.img} />)}
             </div>
             <Link className='link' to='/products'>
-                <StyledButton text='Ver catalogo completo'/>
+                <StyledButton text='Ver catalogo completo' handleClick={() => dispatch(getProducts())}/>
             </Link>
         </div>
     )

--- a/client/src/Components/Home.js
+++ b/client/src/Components/Home.js
@@ -1,27 +1,25 @@
 import React from 'react';
 import Filters from './Filters/Filters.js';
-import { useEffect } from 'react';
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { getCategories } from "../actions/actions";
-import { Link } from "react-router-dom";
 import './Home.css';
 import NewsFlyer from './NewsFlyer/NewsFlyer.js';
 
 export function Home() {
 
   const images = ["https://i.ibb.co/1X8bTBj/flyer-mothers-day.png",
-                    "https://i.ibb.co/Vtjchmm/product-one-md.png",
-                    "https://i.ibb.co/ypqTSx7/product-two-md.png"]
+    "https://i.ibb.co/Vtjchmm/product-one-md.png",
+    "https://i.ibb.co/ypqTSx7/product-two-md.png"]
 
   const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(getCategories())
-  })
+  const categories = useSelector(state => state.categories);
+
+  if (!categories.length) dispatch(getCategories())
 
   return (
     <div className='home'>
-      <h1 className={'bg-color-six'} style={{width: '75%'}}>NEWS</h1>
-      <NewsFlyer images = {images}/>
+      <h1 className={'bg-color-six'} style={{ width: '75%' }}>NEWS</h1>
+      <NewsFlyer images={images} />
       <Filters />
     </div>
   );

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import { getProdutsByCategory } from '../../actions/actions.js';
 import { categories } from '../fakeDb.js';
 import { useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom';
 
 export default function Nav() {
 

--- a/client/src/Components/Nav/Nav.js
+++ b/client/src/Components/Nav/Nav.js
@@ -63,10 +63,13 @@ export default function Nav() {
 }
 
 function Menu({data, display, x, y, onClick}) {
+
+    const dispatch = useDispatch();
+
     return(
     <OptionDiv className={'bg-color-six'} 
     style={{display: display, transform: `translate(${x}, ${y})`}}>
-        {data.map(d=><a href={`/products?${d.name}`} className={'link-without-styles'} ><p style={{padding: '10px 0px 10px 0px'}}>{d.name.toUpperCase()}<br/></p></a>)}
+        {data.map(d=><a href={`/products?${d.name}`} className={'link-without-styles'} ><p onClick={()=>dispatch(getProdutsByCategory(d.id))} style={{padding: '10px 0px 10px 0px'}}>{d.name.toUpperCase()}<br/></p></a>)}
     </OptionDiv>);
 }
 

--- a/client/src/Components/Nav/SearcBar/SearchBar.js
+++ b/client/src/Components/Nav/SearcBar/SearchBar.js
@@ -69,7 +69,7 @@ export default function SearchBar() {
         dispatch(getProductsByName(input));
         // setInput('');
         setOpen(false);
-        if (input) window.location.href = window.location + 'products?search=' + input
+        if (input) window.location.href = 'http://localhost:3000/products?search=' + input
         setInput('')
     };
 

--- a/client/src/Components/Nav/SearcBar/SearchBar.js
+++ b/client/src/Components/Nav/SearcBar/SearchBar.js
@@ -29,9 +29,6 @@ export default function SearchBar() {
         setOpen(false);
     }
 
-    useEffect(() => {
-        dispatch(getProducts())
-    }, [])
 
     useEffect(() => {
         if (input.trim().length >= 1) {
@@ -72,12 +69,13 @@ export default function SearchBar() {
         dispatch(getProductsByName(input));
         // setInput('');
         setOpen(false);
-        if (input) window.location.href = window.location + 'products?search'
+        if (input) window.location.href = window.location + 'products?search=' + input
         setInput('')
     };
 
     function onClickSearch() {
-        setDisplayBar('inline')
+        setDisplayBar('inline');
+        dispatch(getProducts())
     }
 
     return (

--- a/client/src/Components/Nav/SearcBar/SearchBar.js
+++ b/client/src/Components/Nav/SearcBar/SearchBar.js
@@ -14,11 +14,11 @@ export default function SearchBar() {
     const products = useSelector(state => state.products);
     const dispatch = useDispatch();
 
-    const[open, setOpen] = useState(false);
+    const [open, setOpen] = useState(false);
     const node = useRef();
 
     const [displayBar, setDisplayBar] = useState('none')
-    
+
     const handleClick = (e) => {
         if (node.current.contains(e.target)) {
             //inside click
@@ -34,7 +34,7 @@ export default function SearchBar() {
     }, [])
 
     useEffect(() => {
-        if(input.trim().length >= 1) {
+        if (input.trim().length >= 1) {
             getResults();
         } else {
             setResults([]);
@@ -72,25 +72,27 @@ export default function SearchBar() {
         dispatch(getProductsByName(input));
         // setInput('');
         setOpen(false);
+        if (input) window.location.href = window.location + 'products?search'
+        setInput('')
     };
 
-    function onClickSearch(){
+    function onClickSearch() {
         setDisplayBar('inline')
     }
 
     return (
         <div className='searchBar' ref={node}>
             <form id='searchBar' onSubmit={handleSubmit}>
-                <MovingInput style = {{display: `${displayBar}`}} 
-                autoComplete='off' type="text" name="products" value={input} placeholder="Search..." onChange={handleInputChange} />
-                <Button handleClick = { onClickSearch }
-                text = {<FaSearch className = { 'font-color-seven' } style={{fontSize: '110%'}}/>}/> 
+                <MovingInput style={{ display: `${displayBar}` }}
+                    autoComplete='off' type="text" name="products" value={input} placeholder="Search..." onChange={handleInputChange} />
+                <Button handleClick={onClickSearch}
+                    text={<FaSearch className={'font-color-seven'} style={{ fontSize: '110%' }} />} />
             </form>
             <div>
                 {open && (
-                    <SearchBarDropdown 
-                        results = {results}
-                        handleQueryResultClick = {handleQueryResultClick}
+                    <SearchBarDropdown
+                        results={results}
+                        handleQueryResultClick={handleQueryResultClick}
                     />
                 )}
             </div>

--- a/client/src/Components/fakeDB-Categories.js
+++ b/client/src/Components/fakeDB-Categories.js
@@ -39,11 +39,11 @@ export const categoriesF = [
 ]
 
 
-const anillos = [{ id: 1, name: 'Un anillo', price: '1002', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '2' },
-{ id: 2, name: 'anillo 1', price: '1000', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '3' },
-{ id: 3, name: 'anillo 2', price: '150', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '5' },
-{ id: 4, name: 'Un anillo mas', price: '10000', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '5' },
-{ id: 5, name: 'anillos', price: '4000', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '5' }
+const manillas = [{ id: 1, name: 'Un manillas', price: '1002', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '2' },
+{ id: 2, name: 'manillas 1', price: '1000', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '3' },
+{ id: 3, name: 'manillas 2', price: '150', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '5' },
+{ id: 4, name: 'Un anilmanillaslo mas', price: '10000', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '5' },
+{ id: 5, name: 'manillas', price: '4000', image: ['https://bodasyweddings.com/wp-content/uploads/2019/04/orden-de-los-anillos-de-boda-y-de-compromiso.jpg'], review: '5' }
 ]
 const collares = [{ id: 2, name: 'collar1234', price: '1000', image: ['https://static.ella-hoy.es/ellahoy/fotogallery/780X0/37755/collares-verano-2012-dorado-con-colgantes.jpg'], review: '3' },
 { id: 2, name: 'Un collar', price: '200', image: ['https://static.ella-hoy.es/ellahoy/fotogallery/780X0/37755/collares-verano-2012-dorado-con-colgantes.jpg'], review: '3' },
@@ -69,15 +69,10 @@ const sets = [{ id: 11, name: 'Un set', price: '1000', image: ['https://i.postim
 { id: 15, name: 'Un set3', price: '1000', image: ['https://i.postimg.cc/yNBLVfmN/Set-combo-Reloj-Pulsera-y-Cadena-con-Diamantes-Simulados-Cz-chapado-en-oro-14-K-12.jpg'], review: '2' },
 { id: 16, name: 'Un set11', price: '4563', image: ['https://i.postimg.cc/yNBLVfmN/Set-combo-Reloj-Pulsera-y-Cadena-con-Diamantes-Simulados-Cz-chapado-en-oro-14-K-12.jpg'], review: '4' }
 ]
-const cuelgaGafas = [{ id: 17, name: 'Un Cuelga Gafas', price: '1000', image: ['https://http2.mlstatic.com/D_NQ_NP_721564-MCO43970127309_112020-O.jpg'], review: '2' },
-{ id: 18, name: 'Un Cuelga Gafas', price: '1000', image: ['https://http2.mlstatic.com/D_NQ_NP_721564-MCO43970127309_112020-O.jpg'], review: '3' },
+const otros = [{ id: 17, name: 'Un Cuelga Gafas Master 2000', price: '1000', image: ['https://http2.mlstatic.com/D_NQ_NP_721564-MCO43970127309_112020-O.jpg'], review: '2' },
+{ id: 18, name: 'Un Cuelga Gafas Sputnik', price: '1000', image: ['https://http2.mlstatic.com/D_NQ_NP_721564-MCO43970127309_112020-O.jpg'], review: '3' },
 
 ]
 
-const alfs = [{ id: 19, name: 'Un Alf', price: '1000', image: ['https://www.tierragamer.com/wp-content/uploads/2018/08/ALF_Fichas.jpg'], review: '5' },
-{ id: 20, name: 'Un Alf', price: '3009', image: ['https://www.tierragamer.com/wp-content/uploads/2018/08/ALF_Fichas.jpg'], review: '5' },
-{ id: 21, name: 'Un Alf', price: '1002', image: ['https://www.tierragamer.com/wp-content/uploads/2018/08/ALF_Fichas.jpg'], review: '4' },
 
-]
-
-export const filtrado = [anillos, collares, aretes, earcuffs, sets, cuelgaGafas, alfs];
+export const filtrado = [aretes, collares, earcuffs,manillas, sets, otros ];

--- a/client/src/Components/fakeDb.js
+++ b/client/src/Components/fakeDb.js
@@ -1,3 +1,5 @@
+import {filtrado} from './fakeDB-Categories';
+
 export const array = [{
     name: "chokers",
     id:"1",
@@ -29,7 +31,8 @@ export const array = [{
             'https://i.ibb.co/TP0L9w9/aretes-kmora.png'],
     review:"5",
     price:"66",
-}]
+}
+, ...filtrado.flat()]
 
 export const categories = [
     {

--- a/client/src/StyledComponents/Button.js
+++ b/client/src/StyledComponents/Button.js
@@ -17,7 +17,8 @@ const StyledButton = styled.button`
     &:hover {
         cursor: pointer;
         background-color: #f0ddd8;
-        font-size: 18px
+        transform: scale(1.1);
+        transition: 0.5s;
     }
 `
 

--- a/client/src/actions/actions.js
+++ b/client/src/actions/actions.js
@@ -33,7 +33,7 @@ export function getCategories(){
 export function getProductsByName(name){
     // aca va el axios.get que pide a la ruta que devuelve productos por query
     // axios.get(`http://localhost:3001/api/search?name=${query}`)
-    return {type: GET_PRODUCTS_BY_NAME, payload: filtrado.flat().filter(object => object.name.includes(name))}
+    return {type: GET_PRODUCTS_BY_NAME, payload: filtrado.flat().filter(object => object.name.toLowerCase().includes(name.toLowerCase()))}
 }
 export function addToCart(product){
     return {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,15 +5,21 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter as Router} from 'react-router-dom';
 import { Provider } from "react-redux";
-import store from "./store/store.js";
+import { store, persistor } from "./store/store.js";
+
+import { PersistGate } from 'redux-persist/integration/react'
 
 ReactDOM.render(
   <Provider store={store}>
-    <Router>
-      <React.StrictMode>
-        <App />
-      </React.StrictMode>
-    </Router>
+    <PersistGate loading={null} persistor={persistor}>
+
+      <Router>
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      </Router>
+
+    </PersistGate>
   </Provider>,
   document.getElementById('root')
 );

--- a/client/src/store/store.js
+++ b/client/src/store/store.js
@@ -2,8 +2,17 @@ import { createStore, applyMiddleware, compose } from "redux";
 import rootReducer from "../reducer/reducer.js";
 import thunk from "redux-thunk";
 
+import { persistStore, persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage' // defaults to localStorage for web
+
+const persistConfig = {
+    key: 'root',
+    storage,
+}
+
+const persistedReducer = persistReducer(persistConfig, rootReducer)
+
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-const store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunk)),);
-
-export default store;
+export let store = createStore(persistedReducer, composeEnhancers(applyMiddleware(thunk)),)
+export let persistor = persistStore(store)


### PR DESCRIPTION
Varios puntos.

Incorporando el resultado de la busqueda para mostrar note que la implementacion que habia tenido en cuenta para conservar la informacion cuando se recargaba la pagina no era muy eficiente. 
Al renderizarse se llamaba a la misma accion al menos dos veces y a aplicarse los ordenamientos se volvia a a hacer varias acciones innecesarias., lo que significaba varios pedidos al backend para algo que no lo necitaba. En tiempo real de ejecucion haria muy denso el flujo de la app.

Para solucinar el tema implemente la libreria Redux-Persist. Lo configure en el store.

Volvi al modelo anterior de que las acciones se disapren cuando se elige la opcion , y ahi se cargue el store. Esto facilita mucho el codigo.

conecte la busqueda con la visualizacion de los resultados.

acomode algunos dispatch que se disparaban sin sentido

puse <Links> con scroll al  comienzo.

conecte las bases de datos falsas para que se muestren todos los porductos falsos


**Si se observa el fujo dle store, ahora solo se hacen los dispatch necesarios. lo que significa menos llamados al back  y mayor  fluidez**

**importante**
## Hacer  npm install redux-persist

Documentacion : https://www.npmjs.com/package/redux-persist

chau, tengo sueño. 

Ultimo agregado - reciente
arregle el boton deshacer del orenamiento
el menu desplegable de categrias redirige y recarga la pagina para mostrar la opcion seleccioanda
arregle el hover del styledbutton que movia la pantalla
