### PR TITLE
fix(client/searchbardropdown): fix css bug

### DIFF
--- a/client/src/Components/Nav/SearcBar/SearchBarDropdown/SearchBarDropdown.css
+++ b/client/src/Components/Nav/SearcBar/SearchBarDropdown/SearchBarDropdown.css
@@ -4,6 +4,7 @@
     top: 70%;
     left: 25%;
     right: 0;
+    z-index: 99;
     width: 60%;
     border: 1px solid #201414;
     border-radius: 5px;


### PR DESCRIPTION
Modifiqué una linea de css que arregla que el dropdown no quede por detras de las demas imagenes