### PR TITLE
feat(superAdmin): added superAdmin role to User Model & adapted routes for superAdmin usage

### DIFF
--- a/api/src/controllers/product.js
+++ b/api/src/controllers/product.js
@@ -34,7 +34,7 @@ const createProduct = async (req, res) => {
       categories,
     } = req.body;
     if (!name || name.trim().length === 0) return res.status(404).send('Campo faltante: nombre');
-    if (!description || description.trim().length === 0) return res.status(404).send('Campo faltante: nombre');
+    if (!description || description.trim().length === 0) return res.status(404).send('Campo faltante: descripción');
     if (!verifyNumber(price).veracity) return res.status(400).send(verifyNumber(price, 'Precio').msg);
     if (!verifyNumber(stockAmount).veracity) return res.status(400).send(verifyNumber(stockAmount, 'Stock').msg);
     if (!verifyArray(categories)) return res.status(400).send('No se seleccionó una categoría');

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -133,10 +133,11 @@ const disableUser = async (req, res) => {
     idAdmin,
   } = req.body;
   try {
+    const adminTypes = ['admin', 'superAdmin'];
     const admin = await User.findOne({
       where: {
         id: idAdmin,
-        role: 'admin' || 'superAdmin',
+        role: adminTypes,
       },
     });
     if (!admin) return res.status(404).send('Acceso denegado. El usuario no es admin');
@@ -146,7 +147,7 @@ const disableUser = async (req, res) => {
         role: 'superAdmin',
       },
     });
-    if (isSuperAdmin) return res.status(404).send('No se puede eliminar al superAdmin');
+    if (isSuperAdmin.id === idUser) return res.status(404).send('No se puede eliminar al superAdmin');
     const user = await User.update({
       role: 'banned',
     }, {

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -170,16 +170,24 @@ const promoteUserDemoteAdmin = async (req, res) => {
   } = req.body;
   try {
     if (!role || (role !== 'user' && role !== 'admin' && role !== 'superAdmin')) return res.status(400).send('No se envio ningún rol válido.');
+    if (role === 'superAdmin') return res.status(400).send('Acceso denegado. No se puede asignar rol superAdmin');
     if (!idUser) return res.status(400).send('No se recibe ninguna id de usuario.');
     if (!idAdmin) return res.status(400).send('No se recibe ninguna id de admin.');
-    // if (idUser === env.superadmin) return res.status(400).send('No puedes modificar el rol al super dios.');
+    const adminTypes = ['admin', 'superAdmin'];
     const admin = await User.findOne({
       where: {
         id: idAdmin,
-        role: 'admin' || 'superAdmin',
+        role: adminTypes,
       },
     });
     if (!admin) return res.status(400).send('Acceso denegado.');
+    const superAdmin = await User.findOne({
+      where: {
+        role: 'superAdmin',
+      },
+    });
+    if (!superAdmin) return res.status(400).send('La DB está vacía.');
+    if (superAdmin.id === idUser) return res.status(400).send('No puedes modificar el rol al super dios.');
     const user = await User.findOne({
       where: {
         id: idUser,

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -28,7 +28,7 @@ const createUser = async (req, res) => {
     if (emailFound) return res.status(400).send('Ese email ya está siendo utilizado');
     const firstUser = await User.findAll();
     let role = 'user';
-    if (!firstUser.length) role = 'admin';
+    if (!firstUser.length) role = 'superAdmin';
     await User.create({
       id,
       email,
@@ -108,7 +108,7 @@ const getUserAdmin = async (req, res) => {
   } = req.params;
   try {
     const user = await User.findByPk(idUser);
-    if (user && user.role === 'admin') return res.sendStatus(200);
+    if (user && (user.role === 'admin' || user.role === 'superAdmin')) return res.sendStatus(200);
     return res.status(404).send('Acceso denegado. El usuario no es admin');
   } catch (err) {
     return res.status(500).send('Internal server error');
@@ -136,14 +136,17 @@ const disableUser = async (req, res) => {
     const admin = await User.findOne({
       where: {
         id: idAdmin,
-        role: 'admin',
+        role: 'admin' || 'superAdmin',
       },
     });
     if (!admin) return res.status(404).send('Acceso denegado. El usuario no es admin');
     if (admin.id === idUser) return res.status(404).send('Error: no puede bloquearse a uno mismo');
-    // Falta validar que ningun admin pueda borrar al superadmin
-    // ¿Como reconocer el idSuperAdmin? ¿De dónde viene este dato?
-    // if (idUser === idSuperAdmin) return res.status(404).send('No se puede eliminar al dueño');
+    const isSuperAdmin = await User.findOne({
+      where: {
+        role: 'superAdmin',
+      },
+    });
+    if (isSuperAdmin) return res.status(404).send('No se puede eliminar al superAdmin');
     const user = await User.update({
       role: 'banned',
     }, {
@@ -166,14 +169,14 @@ const promoteUserDemoteAdmin = async (req, res) => {
     role,
   } = req.body;
   try {
-    if (!role || (role !== 'user' && role !== 'admin')) return res.status(400).send('No se envio ningún rol válido.');
+    if (!role || (role !== 'user' && role !== 'admin' && role !== 'superAdmin')) return res.status(400).send('No se envio ningún rol válido.');
     if (!idUser) return res.status(400).send('No se recibe ninguna id de usuario.');
     if (!idAdmin) return res.status(400).send('No se recibe ninguna id de admin.');
     // if (idUser === env.superadmin) return res.status(400).send('No puedes modificar el rol al super dios.');
     const admin = await User.findOne({
       where: {
         id: idAdmin,
-        role: 'admin',
+        role: 'admin' || 'superAdmin',
       },
     });
     if (!admin) return res.status(400).send('Acceso denegado.');

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -26,13 +26,16 @@ const createUser = async (req, res) => {
       },
     });
     if (emailFound) return res.status(400).send('Ese email ya está siendo utilizado');
+    const firstUser = await User.findAll();
+    let role = 'user';
+    if (!firstUser.length) role = 'admin';
     await User.create({
       id,
       email,
       displayName,
       phone,
       birthday: birthdayNew,
-      role: 'user',
+      role,
     });
     return res.status(201).send('Usuario creado correctamente!');
   } catch (err) {

--- a/api/src/helpers/middlewares.js
+++ b/api/src/helpers/middlewares.js
@@ -1,5 +1,3 @@
-/* eslint-disable indent */
-
 const {
   verifyString,
 } = require('./functionHelpers');
@@ -9,21 +7,14 @@ const {
 
 async function corroborarAdmin(req, res, next) {
   const idToken = req.headers['access-token'];
-  console.log(req.headers);
-  if (idToken != null && idToken !== undefined && verifyString(idToken)) {
-    console.log('as');
-        const user = await User.findOne({
-          where: {
-            id: idToken,
-          },
-        });
+  if (idToken !== null && idToken !== undefined && verifyString(idToken)) {
+    const user = await User.findByPk(idToken);
 
-        if (!user) return res.status(400).send('El usuario no existe');
-        if (user.role !== 'user') return res.status(400).send('El usuario no es administrador');
-        return next();
-      // eslint-disable-next-line arrow-body-style
+    if (!user) return res.status(400).send('El usuario no existe');
+    if (user.role === 'user' || user.role === 'banned') return res.status(400).send('El usuario no es administrador');
+    return next();
   }
-    return res.status(400).send('Token incorrecta.');
+  return res.status(400).send('Token incorrecta.');
 }
 
 module.exports = {

--- a/api/src/models/User.js
+++ b/api/src/models/User.js
@@ -28,7 +28,7 @@ module.exports = (sequelize) => {
       type: DataTypes.STRING,
     },
     role: {
-      type: DataTypes.ENUM(['user', 'admin', 'banned']),
+      type: DataTypes.ENUM(['user', 'admin', 'banned', 'superAdmin']),
       defaultValue: 'user',
     },
   },


### PR DESCRIPTION
fix(api/userCreate): when DB depleted, now first User is Admin
fix(api/UserModel): added superAdmin value to role Enum
fix(api/user): added superAdmin to validations. If DB is empty, first user is superAdmin
fix(api/JWT): added superAdmin to token validations
fix(api/promoteDemote): avoids touching superAdmin role