### PR TITLE
feat(analytics): added GET/ordersAnalytics, updated PUT/order (in progress), & more fixes

### DIFF
--- a/api/src/controllers/analytics.js
+++ b/api/src/controllers/analytics.js
@@ -4,7 +4,7 @@ const {
   Product,
 } = require('../models/index');
 
-const getOrdersForStatistics = async (req, res) => {
+const getOrdersForAnalytics = async (req, res) => {
   const {
     type,
   } = req.body;
@@ -57,5 +57,5 @@ const getOrdersForStatistics = async (req, res) => {
 };
 
 module.exports = {
-  getOrdersForStatistics,
+  getOrdersForAnalytics,
 };

--- a/api/src/controllers/analytics.js
+++ b/api/src/controllers/analytics.js
@@ -12,7 +12,7 @@ const getOrdersForAnalytics = async (req, res) => {
   if (type !== 'productAmountPerDate'
   && type !== 'totalsPerDateByUsers'
   && type !== 'totalsPerDate') return res.status(404).send('Tipo de estadística incorrecto');
-  const statusTypes = ['PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
+  const statusTypes = ['paidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
   try {
     if (type === 'productAmountPerDate') {
       const orders = await Order.findAll({

--- a/api/src/controllers/analytics.js
+++ b/api/src/controllers/analytics.js
@@ -20,23 +20,23 @@ const getOrdersForAnalytics = async (req, res) => {
           status: statusTypes,
         },
         attributes: ['total', 'endTimestamp'],
-        include: {
+        include: [{
           model: Product, attributes: ['name'],
-        },
+        }],
       });
       if (!orders.length) return res.status(404).send('No se encontraron órdenes pagadas');
       return res.json(orders);
     }
 
-    if (type === 'TotalsPerDateByUsers') {
+    if (type === 'totalsPerDateByUsers') {
       const orders = await Order.findAll({
         where: {
           status: statusTypes,
         },
         attributes: ['total', 'endTimestamp'],
-        include: {
+        include: [{
           model: User, attributes: ['displayName'],
-        },
+        }],
       });
       if (!orders.length) return res.status(404).send('No se encontraron órdenes pagadas');
       return res.json(orders);

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -161,10 +161,17 @@ const modifyOrder = async (req, res) => {
       const totalOrder = order.products.reduce(
         (total, current) => total + current.orderline.subtotal, 0,
       );
+      for (let i = 0; i < order.products.length; i += 1) {
+        const product = await Product.findByPk(order.products[i].id);
+        if (product) {
+          product.stockAmount = order.products[i].stockAmount - order.products[i].orderline.amount;
+          await product.save();
+        }
+      }
       order.status = status;
       order.total = totalOrder;
       order.endTimestamp = new Date();
-      // D) AGREGAR UUID a order.OrderNumber
+      // E) AGREGAR UUID a order.OrderNumber
       // order.orderNumber = ???
       await order.save();
       return res.send('La compra fue exitosa! Revisa tu email');

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -154,16 +154,24 @@ const modifyOrder = async (req, res) => {
     });
     if (!order) return res.status(400).send('La orden no existe!');
 
-    // if (order.status === 'cart' && status === 'paidPendingDispatch') {
+    if (order.status === 'cart' && status === 'paidPendingDispatch') {
     // PREGUNTAR AL FRONT POR EL TOTAL SI VIENE O NO DEL PAGO REALIZADO
     // DEBERÍA:
     // A) SUMAR LOS SUBTOTALES Y GUARDARLO EN ATRIBUTO 'TOTAL'
     // B) IR A C/PRODUCT Y CAMBIAR SU STOCK (RESTAR EL AMOUNT DEL ORDERLINE)
     // C) ENVIAR EMAIL DE CONFIRMACION DE COMPRA
-    // }
+      const total = order.products.reduce(
+        (totalSum, product) => totalSum + product.orderline.subtotal, 0,
+      );
+      order.total = total;
+      await order.save();
+      return res.json(order);
+      // return res.send('La compra fue exitosa!');
+    }
     // if (order.status === 'paidPendingDispatch'
     // && (status === 'deliveryInProgress' || status === 'canceled')) {
     // DEBERIA: ENVIAR EMAIL DE ENVÍO EN CAMINO EN CASO 'deliveryInProgress
+
     // }
     // if (order.status === 'deliveryInProgress' && status === 'finished') {
 

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -176,7 +176,7 @@ const modifyOrder = async (req, res) => {
       await order.save();
       return res.send('La compra fue exitosa! Revisa tu email');
     }
-
+    // LO SIGUIENTE ES CÓDIGO DEL MODELO VIEJO: BORRAR/ACTUALIZAR
     // if (status === 'deliveryPending') {
     //   if (!order) return res.status(404).send(`La orden id ${id} no posee un carrito`);
     //   if (!order.products.length) return res.status(400).send('La orden no tiene productos.');

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -284,11 +284,11 @@ const emptyCartOrProduct = async (req, res) => {
   } catch (err) { return res.status(500).send('Internal server error. Producto no eliminado'); }
 };
 
-const getOrders = async (req, res) => {
+const getAllOrdersNotCart = async (req, res) => {
   let {
     status,
   } = req.query;
-  if (!status) status = ['cart', 'PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
+  if (!status) status = ['PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
   try {
     const result = await Order.findAll({
       where: {
@@ -446,7 +446,7 @@ module.exports = {
   modifyOrder,
   editCartAmount,
   emptyCartOrProduct,
-  getOrders,
+  getAllOrdersNotCart,
   getCartByUser,
   getOrderById,
   getAllOrdersByIdUser,

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -288,7 +288,7 @@ const getOrders = async (req, res) => {
   let {
     status,
   } = req.query;
-  if (!status) status = ['cart', 'deliveryPending', 'delivered'];
+  if (!status) status = ['cart', 'PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
   try {
     const result = await Order.findAll({
       where: {

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -160,23 +160,15 @@ const modifyOrder = async (req, res) => {
     // A) SUMAR LOS SUBTOTALES Y GUARDARLO EN ATRIBUTO 'TOTAL'
     // B) IR A C/PRODUCT Y CAMBIAR SU STOCK (RESTAR EL AMOUNT DEL ORDERLINE)
     // C) ENVIAR EMAIL DE CONFIRMACION DE COMPRA
-      const total = order.products.reduce(
-        (totalSum, product) => totalSum + product.orderline.subtotal, 0,
+      const totalOrder = order.products.reduce(
+        (total, current) => total + current.orderline.subtotal, 0,
       );
-      order.total = total;
+      order.status = status;
+      order.total = totalOrder;
       await order.save();
       return res.json(order);
       // return res.send('La compra fue exitosa!');
     }
-    // if (order.status === 'paidPendingDispatch'
-    // && (status === 'deliveryInProgress' || status === 'canceled')) {
-    // DEBERIA: ENVIAR EMAIL DE ENVÍO EN CAMINO EN CASO 'deliveryInProgress
-
-    // }
-    // if (order.status === 'deliveryInProgress' && status === 'finished') {
-
-    // }
-    return res.status(404).send(`Error: el status ${status} no puede cambiar el status ${order.status}`);
 
     // if (status === 'deliveryPending') {
     //   if (!order) return res.status(404).send(`La orden id ${id} no posee un carrito`);
@@ -195,7 +187,7 @@ const modifyOrder = async (req, res) => {
     //   order.status = status;
     //   order.endTimestamp = new Date();
     //   await order.save();
-    //   return res.send('La orden fue correctamente modificada!');
+    return res.send('La orden fue correctamente modificada!');
     // }
   } catch (err) {
     return res.status(500).send('Internal server error. Orden no fue modificada');
@@ -296,7 +288,7 @@ const getAllOrdersNotCart = async (req, res) => {
   let {
     status,
   } = req.query;
-  if (!status) status = ['PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
+  if (!status) status = ['paidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
   try {
     const result = await Order.findAll({
       where: {

--- a/api/src/controllers/order.js
+++ b/api/src/controllers/order.js
@@ -147,8 +147,6 @@ const modifyOrder = async (req, res) => {
     && status !== 'finished'
     && status !== 'canceled') return res.status(400).send('No se puede implemetar ese status!');
 
-    // Si el status es paidPendingDispatch busca carrito, sino lo buscara como deliveryPending
-    // const statusSearch = status === 'deliveryPending' ? 'cart' : 'deliveryPending';
     const order = await Order.findByPk(id, {
       include: Product,
     });
@@ -165,9 +163,11 @@ const modifyOrder = async (req, res) => {
       );
       order.status = status;
       order.total = totalOrder;
+      order.endTimestamp = new Date();
+      // D) AGREGAR UUID a order.OrderNumber
+      // order.orderNumber = ???
       await order.save();
-      return res.json(order);
-      // return res.send('La compra fue exitosa!');
+      return res.send('La compra fue exitosa! Revisa tu email');
     }
 
     // if (status === 'deliveryPending') {

--- a/api/src/controllers/statistics.js
+++ b/api/src/controllers/statistics.js
@@ -1,0 +1,61 @@
+const {
+  Order,
+  User,
+  Product,
+} = require('../models/index');
+
+const getOrdersForStatistics = async (req, res) => {
+  const {
+    type,
+  } = req.body;
+  if (!type || !type.trim().length) return res.status(404).send('No se envió un tipo de estadística');
+  if (type !== 'productAmountPerDate'
+  && type !== 'totalsPerDateByUsers'
+  && type !== 'totalsPerDate') return res.status(404).send('Tipo de estadística incorrecto');
+  const statusTypes = ['PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled'];
+  try {
+    if (type === 'productAmountPerDate') {
+      const orders = await Order.findAll({
+        where: {
+          status: statusTypes,
+        },
+        attributes: ['total', 'endTimestamp'],
+        include: {
+          model: Product, attributes: ['name'],
+        },
+      });
+      if (!orders.length) return res.status(404).send('No se encontraron órdenes pagadas');
+      return res.json(orders);
+    }
+
+    if (type === 'TotalsPerDateByUsers') {
+      const orders = await Order.findAll({
+        where: {
+          status: statusTypes,
+        },
+        attributes: ['total', 'endTimestamp'],
+        include: {
+          model: User, attributes: ['displayName'],
+        },
+      });
+      if (!orders.length) return res.status(404).send('No se encontraron órdenes pagadas');
+      return res.json(orders);
+    }
+
+    const orders = await Order.findAll({
+      where: {
+        status: statusTypes,
+      },
+      attributes: ['total', 'endTimestamp'],
+    });
+    if (!orders.length) return res.status(404).send('No se encontraron órdenes pagadas');
+
+    return res.json(orders);
+  } catch (err) {
+    return res.status(500).send('Internal server error');
+  }
+};
+
+module.exports = {
+  getOrdersForStatistics,
+};

--- a/api/src/models/Order.js
+++ b/api/src/models/Order.js
@@ -10,7 +10,7 @@ module.exports = (sequelize) => {
       primaryKey: true,
     },
     status: {
-      type: DataTypes.ENUM(['cart', 'PaidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled']),
+      type: DataTypes.ENUM(['cart', 'paidPendingDispatch', 'deliveryInProgress', 'finished', 'canceled']),
     },
     endTimestamp: { // generar al momento de cerrar compra .
       type: DataTypes.DATE,

--- a/api/src/routes/order.js
+++ b/api/src/routes/order.js
@@ -15,7 +15,7 @@ const {
 const router = Router();
 router.get('/analytics', corroborarAdmin, getOrdersForAnalytics);
 router.get('/:orderId', getOrderById);
-router.get('/', getAllOrdersNotCart);
+router.get('/', corroborarAdmin, getAllOrdersNotCart);
 router.put('/:id', corroborarAdmin, modifyOrder);
 router.delete('/empty', emptyCartOrProduct);
 router.post('/', createOrFindAndUpdateCart);

--- a/api/src/routes/order.js
+++ b/api/src/routes/order.js
@@ -13,9 +13,9 @@ const {
 } = require('../helpers/middlewares');
 
 const router = Router();
+router.get('/analytics', corroborarAdmin, getOrdersForAnalytics);
 router.get('/:orderId', getOrderById);
 router.get('/', getOrders);
-router.get('/analytics', getOrdersForAnalytics);
 router.put('/:id', corroborarAdmin, modifyOrder);
 router.delete('/empty', emptyCartOrProduct);
 router.post('/', createOrFindAndUpdateCart);

--- a/api/src/routes/order.js
+++ b/api/src/routes/order.js
@@ -3,7 +3,7 @@ const {
 } = require('express');
 const {
   createOrFindAndUpdateCart, modifyOrder,
-  emptyCartOrProduct, getOrders, getOrderById, testNodeMailer,
+  emptyCartOrProduct, getAllOrdersNotCart, getOrderById, testNodeMailer,
 } = require('../controllers/order');
 const {
   getOrdersForAnalytics,
@@ -15,7 +15,7 @@ const {
 const router = Router();
 router.get('/analytics', corroborarAdmin, getOrdersForAnalytics);
 router.get('/:orderId', getOrderById);
-router.get('/', getOrders);
+router.get('/', getAllOrdersNotCart);
 router.put('/:id', corroborarAdmin, modifyOrder);
 router.delete('/empty', emptyCartOrProduct);
 router.post('/', createOrFindAndUpdateCart);

--- a/api/src/routes/order.js
+++ b/api/src/routes/order.js
@@ -5,7 +5,9 @@ const {
   createOrFindAndUpdateCart, modifyOrder,
   emptyCartOrProduct, getOrders, getOrderById, testNodeMailer,
 } = require('../controllers/order');
-
+const {
+  getOrdersForAnalytics,
+} = require('../controllers/analytics');
 const {
   corroborarAdmin,
 } = require('../helpers/middlewares');
@@ -13,6 +15,7 @@ const {
 const router = Router();
 router.get('/:orderId', getOrderById);
 router.get('/', getOrders);
+router.get('/analytics', getOrdersForAnalytics);
 router.put('/:id', corroborarAdmin, modifyOrder);
 router.delete('/empty', emptyCartOrProduct);
 router.post('/', createOrFindAndUpdateCart);


### PR DESCRIPTION
- Feat(analytics): added GET/ordersAnalytics, used to serve different sets of info in order to render different analytical charts.

- Fix PUT/order: started (not ended) the changes in this route to align route with all statuses of the Order model. Now changes correctly order's status from 'cart' -> to 'paidPendingDispatch'. Calculates the order's 'total', substracts the stockAmount for each product, and adds a timestamp for order paid. Missing uuid for orderNumber.

- Fix GET/orders: now gets all orders EXCEPT those with status 'cart'.

- Fixes with typo errors 'PaidPendingDispatch' changed in model Orders (now 'paidPendingDispatch). Updated routes that used that incorrect status.
